### PR TITLE
Include the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Jason Ish <jason@codemonkey.net>"]
 edition = "2021"
 description = "Simple-IDS with Suricata and EveBox"
 homepage = "https://evebox.org/simple-ids/"
+repository = "https://github.com/jasonish/simple-ids"
 license = "MIT"
 
 # Some tweaks to reduce binary size.


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).